### PR TITLE
color animation using currentColor

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
 	<a data-property="box-shadow" data-from="none" data-to="inset -75px -75px 400px #000" data-author="yuritkachenko"></a>
 	<a data-property="box-shadow" data-from="inset 0 0 75px 75px slategray, 0 0 0 slategray" data-to="inset 0 0 35px 35px transparent, 0 0 75px 50px transparent" style="background: transparent; border-radius: 1px;" data-author="kizmarh"></a>
 	<a data-property="color" data-from="white" data-to="black"></a>
+    <a data-property="color" data-from="#FFF" data-to="rgba(0,17,34,0.6)" style="background: currentColor; outline: 22px double; background-image: radial-gradient(rgba(112,128,144,.5) 32%, rgba(112,128,144,0) 63%), radial-gradient(closest-side, rgba(112,128,144,0) 55%, rgba(112,128,144,.4) 52%), linear-gradient(0, rgba(112,128,144,.25) 50%, rgba(112,128,144,0) 50%), linear-gradient(top,rgba(112,128,144,.8),rgba(112,128,144,0)), linear-gradient(top,rgba(4,32,60,.57),rgba(4,32,60,.57)); background-size: 100% 100%, 15px 15px, 30px 60px, 100% 100%;" data-author="kizmarh"></a>
 	<a data-property="font-size" data-from="60px" data-to="300px"></a>
 	<a data-property="height" data-from="150px" data-to="0"></a>
 	<a data-property="letter-spacing" data-from="0" data-to="100px"></a>


### PR DESCRIPTION
I tried to use the `currentColor` transitioning alongside with the `color`, but in webkit there are _a lot_ of strange issues (except for it not understanding `currentColor` for box-shadows etc.):
- The main problem: webkits don't animate the properties that use `currentColor`, but Firefox do, so in Firefox you could see the changing of the background.
- But the webkit still animates the `border` and `outline` properties, so I added an extra outline (and made it half the color of the changed number to make the ).

Since, it's somewhat non-crossbrowser thing, so I'll understand if you don't want it to be merged in the animatable. Or, if the animating of the outline+color would be enough, I can strip the whole background animation from the pull request.
