### PR TITLE
Possible fix for demo number issues in Safari.

### DIFF
--- a/style.css
+++ b/style.css
@@ -47,7 +47,6 @@ div[role="main"]:after {
 		font-size: 60px;
 		line-height: 150px;
 		text-align: center;
-		counter-increment: demo;
 	}
 	
 	body.in-page a[data-property]:not(:target) {
@@ -74,7 +73,9 @@ div[role="main"]:after {
 			letter-spacing: 0;
 		}
 	
-		a[data-property]:before {
+		a[data-property]:before 
+		{
+			counter-increment: demo;
 			content: counter(demo);
 		}
 	


### PR DESCRIPTION
Hi Lea,

Thanks for your great site with animation examples.

In Safari (5.1 on W7) I noticed that the demo numbers decrement when hovering over certain demo tiles (e.g. demo 9). 

I found a solution/workaround: by moving the counter-increment to the :before pseudo element, the demo counter behaves OK in Safari.

I hope this helps.
