### PR TITLE
rename skew(...) to skewX(...)

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 	<a data-property="top" data-from="0" data-to="100px" style="position:relative"></a>
 	<a data-property="transform" data-from="rotate(0deg)" data-to="rotate(360deg)"></a>
 	<a data-property="transform" data-from="scale(1)" data-to="scale(2)"></a>
-	<a data-property="transform" data-from="skew(0deg)" data-to="skew(180deg)"></a>
+	<a data-property="transform" data-from="skewX(0deg)" data-to="skewX(180deg)"></a>
 	<a data-property="transform" data-from="rotate(0deg) scale(1)" data-to="rotate(360deg) scale(0)"></a>
 	<a data-property="transform" data-from="perspective(400px) rotateY(0deg)" data-to="perspective(400px) rotateY(360deg)"></a>
 	<a data-property="transform" data-from="perspective(400px) rotateX(0deg)" data-to="perspective(400px) rotateX(360deg)" data-author="calvein"></a>


### PR DESCRIPTION
skew() has been removed from the spec and from Mozilla's implementation.
