### PR TITLE
fix: add transparent outline color

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,6 +48,7 @@ div[role="main"]:after {
 		line-height: 150px;
 		text-align: center;
 		counter-increment: demo;
+		outline-color: transparent;
 	}
 	
 	body.in-page a[data-property]:not(:target) {


### PR DESCRIPTION
Some browser styles add an outline to focused elements, which makes for a few strange interactions when you click the animations you want to see in action.

![outline-color-chrome-2](https://cloud.githubusercontent.com/assets/887163/3384403/966ea060-fc59-11e3-8c78-9821f8af8bdc.png)

If you have a finicky graphics card like me, this is specially visible

![outline-color-chrome-1](https://cloud.githubusercontent.com/assets/887163/3384465/b80594bc-fc5a-11e3-8847-f4feb8dce454.png)

I don't know if the outline's intended, but this PR tries to minimize that by setting the `outline-color` to transparent.

Thanks!
