### PR TITLE
Avoid "fake" range in regex character class

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ StyleFix.styleElement(style);
 document.head.appendChild(style);
 
 setTimeout(onhashchange = function() {
-	var target = location.hash? $(location.hash.replace(/([^\w-#])/g, '\\$1')) : null;
+	var target = location.hash? $(location.hash.replace(/([^#\w-])/g, '\\$1')) : null;
 	
 	if(!target) {
 		document.body.className = 'home';


### PR DESCRIPTION
Visually, it seems that `\w-#` is a range.

Moved the dash to the end of the character class, to make it clear it is a literal dash.

Also, moved the `#` to the start because `[^\w#-]` is uglier :)

> Note: The "line break at EOF" change was inserted by the GitHub web editor.
